### PR TITLE
Preserve path when moving in/out of vm

### DIFF
--- a/.govuk
+++ b/.govuk
@@ -44,7 +44,12 @@ function vm_directory {
 
 function vm {
   if [[ $OSTYPE == darwin* ]] ; then
-     vm_directory && vagrant ssh
+    if [ "${PWD##$HOME/govuk/}" != "${PWD}" ] ; then
+      app_name=${PWD##$HOME/govuk/}
+      VAGRANT_CWD=$HOME/govuk/govuk-puppet/development-vm vagrant ssh -- -t "cd /var/govuk/$app_name && bash -l"
+    else
+      VAGRANT_CWD=$HOME/govuk/govuk-puppet/development-vm vagrant ssh
+    fi;
   else
     echo "Sorry, you are already inside vagrant."
   fi;


### PR DESCRIPTION
Vagrant takes an environment variable for the current working directory
so you don't have to change directory to enter the dev vm.

Also... with some ssh arguments we can directly go to a particular
directory under ~/govuk.

This means if you are in an app directory on your host machine,
vm will take you to that same directory in the vm, and when
you exit the vm you are back where you were.

This assumes you're using bash as your shell inside the VM.
